### PR TITLE
support base 4.7

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,6 +5,7 @@ import Options.Applicative.Types
 import Cabal.Simple
 import Cabal.Haddock
 import Control.Monad hiding (forM_)
+import Data.Monoid
 import qualified Data.Set as Set
 import Text.Printf
 import System.Directory


### PR DESCRIPTION
With base 4.7, standalone-haddock fails to compile, with messages like this:

```
src/Main.hs:37:44:
    Not in scope: ‘<>’
    Perhaps you meant one of these:
      ‘>’ (imported from Prelude), ‘<’ (imported from Prelude),
      ‘</>’ (imported from System.FilePath)
```

Adding `import Data.Monoid` will make it compile with base 4.7.

Alternatively, if you do not want to support base 4.7, please add the constraint `base >= 4.8` to the cabal file.